### PR TITLE
jax API updates

### DIFF
--- a/main_Burgers1d.py
+++ b/main_Burgers1d.py
@@ -6,8 +6,8 @@ import argparse
 # jax
 import jax.numpy as jnp
 from jax import vmap, jit
-from jax.config import config; 
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 import numpy as onp
 from numpy import random
 # solver

--- a/main_DarcyFlow2d.py
+++ b/main_DarcyFlow2d.py
@@ -6,8 +6,8 @@ import argparse
 # jax
 import jax.numpy as jnp
 from jax import grad, vmap
-from jax.config import config; 
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 import numpy as onp
 from numpy import random
 

--- a/main_Eikonal2d.py
+++ b/main_Eikonal2d.py
@@ -5,8 +5,8 @@ import argparse
 
 # jax
 import jax.numpy as jnp
-from jax.config import config; 
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 import numpy as onp
 # solver
 from src.solver import solver_GP

--- a/main_NonLinElliptic2d.py
+++ b/main_NonLinElliptic2d.py
@@ -5,8 +5,8 @@ import argparse
 # jax
 import jax.numpy as jnp
 from jax import grad, vmap, jit
-from jax.config import config; 
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 
 # numpy
 import numpy as onp

--- a/src/Gram_matrice.py
+++ b/src/Gram_matrice.py
@@ -1,9 +1,8 @@
 # JAX
 import jax.numpy as jnp
 from jax import vmap
-from jax.config import config; 
-import jax.ops as jop
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 
 # numpy
 import numpy as onp

--- a/src/Gram_matrice.py
+++ b/src/Gram_matrice.py
@@ -61,42 +61,42 @@ def Gram_matrix_assembly(X_domain, X_boundary, eqn = 'Nonlinear_elliptic', kerne
         Theta = jnp.zeros((4*N_domain + N_boundary, 4*N_domain + N_boundary))
         # interior v.s. interior 
         val = vmap(lambda x1, x2, y1, y2: K.D_x1_D_y1_kappa(x1, x2, y1, y2, kernel_parameter))(XXdd0.flatten(),XXdd1.flatten(),jnp.transpose(XXdd0).flatten(),jnp.transpose(XXdd1).flatten())
-        Theta = jop.index_update(Theta, jop.index[0:N_domain, 0:N_domain], jnp.reshape(val, (N_domain, N_domain)))
+        Theta = Theta.at[0:N_domain, 0:N_domain].set(jnp.reshape(val, (N_domain, N_domain)))
         
         val = vmap(lambda x1, x2, y1, y2: K.D_x1_D_y2_kappa(x1, x2, y1, y2, kernel_parameter))(XXdd0.flatten(),XXdd1.flatten(),jnp.transpose(XXdd0).flatten(),jnp.transpose(XXdd1).flatten())
-        Theta = jop.index_update(Theta, jop.index[0:N_domain, N_domain:2*N_domain], jnp.reshape(val, (N_domain, N_domain)))
-        Theta = jop.index_update(Theta, jop.index[N_domain:2*N_domain, 0:N_domain], jnp.transpose(jnp.reshape(val, (N_domain, N_domain))))
+        Theta = Theta.at[0:N_domain, N_domain:2*N_domain].set(jnp.reshape(val, (N_domain, N_domain)))
+        Theta = Theta.at[N_domain:2*N_domain, 0:N_domain].set(jnp.transpose(jnp.reshape(val, (N_domain, N_domain))))
         
         val = vmap(lambda x1, x2, y1, y2: K.D_x1_DD_y2_kappa(x1, x2, y1, y2, kernel_parameter))(XXdd0.flatten(),XXdd1.flatten(),jnp.transpose(XXdd0).flatten(),jnp.transpose(XXdd1).flatten())
-        Theta = jop.index_update(Theta, jop.index[0:N_domain, 2*N_domain:3*N_domain], jnp.reshape(val, (N_domain, N_domain)))
-        Theta = jop.index_update(Theta, jop.index[2*N_domain:3*N_domain, 0:N_domain], jnp.transpose(jnp.reshape(val, (N_domain, N_domain))))
+        Theta = Theta.at[0:N_domain, 2*N_domain:3*N_domain].set(jnp.reshape(val, (N_domain, N_domain)))
+        Theta = Theta.at[2*N_domain:3*N_domain, 0:N_domain].set(jnp.transpose(jnp.reshape(val, (N_domain, N_domain))))
         
         val = vmap(lambda x1, x2, y1, y2: K.D_x2_D_y2_kappa(x1, x2, y1, y2, kernel_parameter))(XXdd0.flatten(),XXdd1.flatten(),jnp.transpose(XXdd0).flatten(),jnp.transpose(XXdd1).flatten())
-        Theta = jop.index_update(Theta, jop.index[N_domain:2*N_domain, N_domain:2*N_domain], jnp.reshape(val, (N_domain, N_domain)))
+        Theta = Theta.at[N_domain:2*N_domain, N_domain:2*N_domain].set(jnp.reshape(val, (N_domain, N_domain)))
         
         val = vmap(lambda x1, x2, y1, y2: K.D_x2_DD_y2_kappa(x1, x2, y1, y2, kernel_parameter))(XXdd0.flatten(),XXdd1.flatten(),jnp.transpose(XXdd0).flatten(),jnp.transpose(XXdd1).flatten())
-        Theta = jop.index_update(Theta, jop.index[N_domain:2*N_domain, 2*N_domain:3*N_domain], jnp.reshape(val, (N_domain, N_domain)))
-        Theta = jop.index_update(Theta, jop.index[2*N_domain:3*N_domain, N_domain:2*N_domain], jnp.transpose(jnp.reshape(val, (N_domain, N_domain))))
+        Theta = Theta.at[N_domain:2*N_domain, 2*N_domain:3*N_domain].set(jnp.reshape(val, (N_domain, N_domain)))
+        Theta = Theta.at[2*N_domain:3*N_domain, N_domain:2*N_domain].set(jnp.transpose(jnp.reshape(val, (N_domain, N_domain))))
         
         val = vmap(lambda x1, x2, y1, y2: K.DD_x2_DD_y2_kappa(x1, x2, y1, y2, kernel_parameter))(XXdd0.flatten(),XXdd1.flatten(),jnp.transpose(XXdd0).flatten(),jnp.transpose(XXdd1).flatten())
-        Theta = jop.index_update(Theta, jop.index[2*N_domain:3*N_domain, 2*N_domain:3*N_domain], jnp.reshape(val, (N_domain, N_domain)))
+        Theta = Theta.at[2*N_domain:3*N_domain, 2*N_domain:3*N_domain].set(jnp.reshape(val, (N_domain, N_domain)))
         
         # interior+boundary v.s. interior+boundary
         val = vmap(lambda x1, x2, y1, y2: K.kappa(x1, x2, y1, y2, kernel_parameter))(XXdbdb0.flatten(),XXdbdb1.flatten(),jnp.transpose(XXdbdb0).flatten(),jnp.transpose(XXdbdb1).flatten())
-        Theta = jop.index_update(Theta, jop.index[3*N_domain:, 3*N_domain:], jnp.reshape(val, (N_domain+N_boundary, N_domain+N_boundary)))
+        Theta = Theta.at[3*N_domain:, 3*N_domain:].set(jnp.reshape(val, (N_domain+N_boundary, N_domain+N_boundary)))
         
         # interior v.s. interior+boundary
         val = vmap(lambda x1, x2, y1, y2: K.D_x1_kappa(x1, x2, y1, y2, kernel_parameter))(XXddb0.flatten(),XXddb1.flatten(),XXddb0_2.flatten(),XXddb1_2.flatten())
-        Theta = jop.index_update(Theta, jop.index[0:N_domain, 3*N_domain:], jnp.reshape(val, (N_domain, N_domain+N_boundary)))
-        Theta = jop.index_update(Theta, jop.index[3*N_domain:, 0:N_domain], jnp.transpose(jnp.reshape(val, (N_domain, N_domain+N_boundary))))
+        Theta = Theta.at[0:N_domain, 3*N_domain:].set(jnp.reshape(val, (N_domain, N_domain+N_boundary)))
+        Theta = Theta.at[3*N_domain:, 0:N_domain].set(jnp.transpose(jnp.reshape(val, (N_domain, N_domain+N_boundary))))
         
         val = vmap(lambda x1, x2, y1, y2: K.D_x2_kappa(x1, x2, y1, y2, kernel_parameter))(XXddb0.flatten(),XXddb1.flatten(),XXddb0_2.flatten(),XXddb1_2.flatten())
-        Theta = jop.index_update(Theta, jop.index[N_domain:2*N_domain, 3*N_domain:], jnp.reshape(val, (N_domain, N_domain+N_boundary)))
-        Theta = jop.index_update(Theta, jop.index[3*N_domain:, N_domain:2*N_domain], jnp.transpose(onp.reshape(val, (N_domain, N_domain+N_boundary))))
+        Theta = Theta.at[N_domain:2*N_domain, 3*N_domain:].set(jnp.reshape(val, (N_domain, N_domain+N_boundary)))
+        Theta = Theta.at[3*N_domain:, N_domain:2*N_domain].set(jnp.transpose(jnp.reshape(val, (N_domain, N_domain+N_boundary))))
         
         val = vmap(lambda x1, x2, y1, y2: K.DD_x2_kappa(x1, x2, y1, y2, kernel_parameter))(XXddb0.flatten(),XXddb1.flatten(),XXddb0_2.flatten(),XXddb1_2.flatten())
-        Theta = jop.index_update(Theta, jop.index[2*N_domain:3*N_domain, 3*N_domain:], jnp.reshape(val, (N_domain, N_domain+N_boundary)))
-        Theta = jop.index_update(Theta, jop.index[3*N_domain:, 2*N_domain:3*N_domain], jnp.transpose(jnp.reshape(val, (N_domain, N_domain+N_boundary))))
+        Theta = Theta.at[2*N_domain:3*N_domain, 3*N_domain:].set(jnp.reshape(val, (N_domain, N_domain+N_boundary)))
+        Theta = Theta.at[3*N_domain:, 2*N_domain:3*N_domain].set(jnp.transpose(jnp.reshape(val, (N_domain, N_domain+N_boundary))))
         return Theta
     elif eqn == 'Eikonal':
         Theta = onp.zeros((4*N_domain + N_boundary, 4*N_domain + N_boundary))

--- a/src/InverseProblems.py
+++ b/src/InverseProblems.py
@@ -3,9 +3,8 @@ import jax.numpy as jnp
 from jax import grad, vmap, hessian, jit
 from functools import partial
 
-import jax.ops as jop
-from jax.config import config; 
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 
 # numpy
 import numpy as onp

--- a/src/PDEs.py
+++ b/src/PDEs.py
@@ -300,10 +300,10 @@ class Burgers(object):
 
         mtx = jnp.zeros((4*self.N_domain+self.N_boundary, 3*self.N_domain))
         mtx1 = jnp.concatenate((-self.alpha*jnp.diag(v2), -self.alpha*jnp.diag(v0), self.nu*jnp.eye(self.N_domain)), axis=1)
-        mtx = jop.index_update(mtx, jop.index[0:self.N_domain, :], mtx1)
-        mtx = jop.index_update(mtx, jop.index[self.N_domain:2*self.N_domain, self.N_domain:2*self.N_domain], jnp.eye(self.N_domain))
-        mtx = jop.index_update(mtx, jop.index[2*self.N_domain:3*self.N_domain, 2*self.N_domain:3*self.N_domain], jnp.eye(self.N_domain))
-        mtx = jop.index_update(mtx, jop.index[3*self.N_domain:4*self.N_domain, :self.N_domain], jnp.eye(self.N_domain))
+        mtx = mtx.at[0:self.N_domain, :].set(mtx1)
+        mtx = mtx.at[self.N_domain:2*self.N_domain, self.N_domain:2*self.N_domain].set(jnp.eye(self.N_domain))
+        mtx = mtx.at[2*self.N_domain:3*self.N_domain, 2*self.N_domain:3*self.N_domain].set(jnp.eye(self.N_domain))
+        mtx = mtx.at[3*self.N_domain:4*self.N_domain, :self.N_domain].set(jnp.eye(self.N_domain))
         ss = jnp.linalg.solve(self.L, mtx)
         return 2*jnp.matmul(jnp.transpose(ss),ss)
     

--- a/src/PDEs.py
+++ b/src/PDEs.py
@@ -4,9 +4,8 @@ from jax import grad, vmap, hessian, jit
 
 from functools import partial
 
-import jax.ops as jop
-from jax.config import config; 
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 
 # numpy
 import numpy as onp

--- a/src/kernels.py
+++ b/src/kernels.py
@@ -1,7 +1,7 @@
 import jax.numpy as jnp
 from jax import grad, jit
-from jax.config import config; 
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 
 from functools import partial # for jit to make codes faster
 

--- a/src/solver.py
+++ b/src/solver.py
@@ -1,8 +1,8 @@
 
 # jax
 import jax.numpy as jnp
-from jax.config import config; 
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 
 import numpy as onp
 


### PR DESCRIPTION
This pull request includes multiple changes to improve the consistency and readability of the codebase by updating the import statements and replacing deprecated methods. The most important changes include modifying import statements for `jax` configuration updates and replacing deprecated `jax.ops.index_update` with the new `jax.numpy` indexing methods.

### Consistency Improvements in Import Statements:

* Updated `jax` import statements to use `import jax` followed by `jax.config.update("jax_enable_x64", True)` in the following files:
  * `main_Burgers1d.py`
  * `main_DarcyFlow2d.py`
  * `main_Eikonal2d.py`
  * `main_NonLinElliptic2d.py`
  * `src/Gram_matrice.py`
  * `src/InverseProblems.py`
  * `src/PDEs.py`
  * `src/kernels.py`
  * `src/solver.py`

- version 0.4.29 #https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-29-june-10-2024:
  - The deprecated jax.config submodule has been removed. To configure JAX use import jax and then reference the config object via jax.config.

### Replacement of Deprecated Methods:

* Replaced `jax.ops.index_update` with the new `jax.numpy` indexing methods in:
  * `def Gram_matrix_assembly` in `src/Gram_matrice.py`
  * `def Hessian_GN` in `src/PDEs.py`

- version 0.3.2 #https://jax.readthedocs.io/en/latest/changelog.html#jax-0-3-2-march-16-2022:
  - The functions jax.ops.index_update, jax.ops.index_add, which were deprecated in 0.2.22, have been removed. Please use [the .at property on JAX arrays](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html) instead, e.g., x.at[idx].set(y). 